### PR TITLE
fix #30: crash on windows 10

### DIFF
--- a/java-keyring/src/main/java/com/github/javakeyring/internal/windows/Advapi32.java
+++ b/java-keyring/src/main/java/com/github/javakeyring/internal/windows/Advapi32.java
@@ -27,6 +27,7 @@
 package com.github.javakeyring.internal.windows;
 
 import com.sun.jna.Library;
+import com.sun.jna.Pointer;
 import com.sun.jna.platform.win32.WinDef.DWORD;
 import com.sun.jna.ptr.PointerByReference;
 
@@ -67,11 +68,10 @@ interface Advapi32 extends Library {
   /**
    * Advapi32.lib
    * @param Credential who's memory we'll free.
-   * @param Flags has one value, set to use existing credential memory or not.
    * @return success or failure.
    */
   public boolean CredFree(
-      PointerByReference Credential
+      Pointer Credential
       );
     
   /**
@@ -86,5 +86,5 @@ interface Advapi32 extends Library {
       DWORD  type,
       DWORD  flags
       );
-  
+
 }

--- a/java-keyring/src/main/java/com/github/javakeyring/internal/windows/Advapi32.java
+++ b/java-keyring/src/main/java/com/github/javakeyring/internal/windows/Advapi32.java
@@ -86,5 +86,4 @@ interface Advapi32 extends Library {
       DWORD  type,
       DWORD  flags
       );
-
 }

--- a/java-keyring/src/main/java/com/github/javakeyring/internal/windows/WinCredentialStoreBackend.java
+++ b/java-keyring/src/main/java/com/github/javakeyring/internal/windows/WinCredentialStoreBackend.java
@@ -67,30 +67,26 @@ public class WinCredentialStoreBackend implements KeyringBackend {
     } catch (Exception ex) {
       throw new PasswordAccessException(ex.getMessage());
     } finally {
-      nativeLibraries.getAdvapi32().CredFree(ref);
+      nativeLibraries.getAdvapi32().CredFree(ref.getValue());
     }
   }
 
   @Override
   public void setPassword(String service, String account, String password) throws PasswordAccessException {
     CREDENTIAL cred = new CREDENTIAL();
-    try {
-      cred.TargetName = service + '|' + account;
-      cred.UserName = account;
-      cred.Type = 1;
-      byte[] bytes = password.getBytes(Charset.forName("UTF-16LE"));
-      Memory passwordMemory = new Memory(bytes.length);
-      passwordMemory.write(0, bytes, 0, bytes.length);
-      cred.CredentialBlob = passwordMemory;
-      cred.CredentialBlobSize = bytes.length;
-      cred.Persist = 2;
-      Boolean success = nativeLibraries.getAdvapi32().CredWriteA(cred, new DWORD(0));
-      passwordMemory.clear();
-      if (!success) {
-        throw new PasswordAccessException("Error code " + nativeLibraries.getKernel32().GetLastError().intValue());
-      }
-    } finally {
-      nativeLibraries.getAdvapi32().CredFree(new PointerByReference(cred.getPointer()));
+    cred.TargetName = service + '|' + account;
+    cred.UserName = account;
+    cred.Type = 1;
+    byte[] bytes = password.getBytes(Charset.forName("UTF-16LE"));
+    Memory passwordMemory = new Memory(bytes.length);
+    passwordMemory.write(0, bytes, 0, bytes.length);
+    cred.CredentialBlob = passwordMemory;
+    cred.CredentialBlobSize = bytes.length;
+    cred.Persist = 2;
+    Boolean success = nativeLibraries.getAdvapi32().CredWriteA(cred, new DWORD(0));
+    passwordMemory.clear();
+    if (!success) {
+      throw new PasswordAccessException("Error code " + nativeLibraries.getKernel32().GetLastError().intValue());
     }
   }
 

--- a/java-keyring/src/test/java/com/github/javakeyring/win/CorruptedHeapTest.java
+++ b/java-keyring/src/test/java/com/github/javakeyring/win/CorruptedHeapTest.java
@@ -1,0 +1,29 @@
+package com.github.javakeyring.win;
+
+import com.github.javakeyring.internal.windows.WinCredentialStoreBackend;
+import com.sun.jna.Platform;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assume.assumeTrue;
+
+/**
+ * Test for crash
+ * @see <a href="https://github.com/javakeyring/java-keyring/issues/30">issue #30</a>
+ */
+public final class CorruptedHeapTest {
+    private static final String SERVICE = "com.github.javakeyring.wincred.test";
+    private static final String ACCOUNT = "username_wincred";
+    private static final String PASSWORD = "password_wincred";
+
+    @Test
+    public void testIfCrashHappens() throws Exception {
+        assumeTrue(Platform.isWindows());
+        WinCredentialStoreBackend backend = new WinCredentialStoreBackend();
+        backend.setPassword(SERVICE, ACCOUNT, PASSWORD);
+        for (int i = 0; i < 50; i++) {
+            assertThat(backend.getPassword(SERVICE, ACCOUNT)).isEqualTo(PASSWORD);
+            Runtime.getRuntime().gc(); // greatly increases chances of a crash
+        }
+    }
+}

--- a/java-keyring/src/test/java/com/github/javakeyring/win/CorruptedHeapTest.java
+++ b/java-keyring/src/test/java/com/github/javakeyring/win/CorruptedHeapTest.java
@@ -5,6 +5,7 @@ import com.sun.jna.Platform;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.junit.Assume.assumeTrue;
 
 /**
@@ -20,10 +21,12 @@ public final class CorruptedHeapTest {
     public void testIfCrashHappens() throws Exception {
         assumeTrue(Platform.isWindows());
         WinCredentialStoreBackend backend = new WinCredentialStoreBackend();
+        catchThrowable(() -> backend.deletePassword(SERVICE, ACCOUNT));
         backend.setPassword(SERVICE, ACCOUNT, PASSWORD);
         for (int i = 0; i < 50; i++) {
             assertThat(backend.getPassword(SERVICE, ACCOUNT)).isEqualTo(PASSWORD);
             Runtime.getRuntime().gc(); // greatly increases chances of a crash
         }
+        backend.deletePassword(SERVICE, ACCOUNT);
     }
 }

--- a/java-keyring/src/test/java/com/github/javakeyring/win/CorruptedHeapTest.java
+++ b/java-keyring/src/test/java/com/github/javakeyring/win/CorruptedHeapTest.java
@@ -1,3 +1,29 @@
+/*
+ * Copyright © 2019, Java Keyring
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the <organization> nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package com.github.javakeyring.win;
 
 import com.github.javakeyring.internal.windows.WinCredentialStoreBackend;

--- a/java-keyring/src/test/java/com/github/javakeyring/win/CorruptedHeapTest.java
+++ b/java-keyring/src/test/java/com/github/javakeyring/win/CorruptedHeapTest.java
@@ -13,7 +13,7 @@ import static org.junit.Assume.assumeTrue;
  * @see <a href="https://github.com/javakeyring/java-keyring/issues/30">issue #30</a>
  */
 public final class CorruptedHeapTest {
-    private static final String SERVICE = "com.github.javakeyring.wincred.test";
+    private static final String SERVICE = "com.github.javakeyring.wincred.testcrash";
     private static final String ACCOUNT = "username_wincred";
     private static final String PASSWORD = "password_wincred";
 


### PR DESCRIPTION
Changes was made:
1. CredFree function takes pointer, not pointer to pointer
2. There is no need to call CredFree in setPassword method. Credential structure is allocated by JNA, not by Credential API call.
