### PR TITLE
Implements support for the modern Mac OS Keyring API.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Use a real password manager for your real secrets. Something like Keypass, Enpas
 ## Implementation ##
 
 __Mac OS X__
-*   Passwords are stored using [OS X Keychain](https://support.apple.com/guide/keychain-access/welcome/mac) using [Keychain Services](https://developer.apple.com/documentation/security/keychain_services/keychain_items) api via "Legacy Password Storage". 
+*   Passwords are stored using [OS X Keychain](https://support.apple.com/guide/keychain-access/welcome/mac) using [Keychain Services](https://developer.apple.com/documentation/security/keychain_services/keychain_items). This is done either via built-in JNA bindings for the legacy API, or [jkeychain](https://github.com/davidafsilva/jkeychain). 
   
 __Linux/Freedesktop__
 *   Passwords are stored using [DBus Secret Service](https://specifications.freedesktop.org/secret-service/), you probably used [Seahorse](https://en.wikipedia.org/wiki/Seahorse_(software)).  Connection is made via the excellent [secret-service](https://github.com/swiesend/secret-service) library.
@@ -104,7 +104,6 @@ Outstanding work:
 *   Support for build tools like Maven/Gradle.
 *   Perhaps optional UI requests for passwords (Wincred/secret-service have Apis at least to prompt users).
 *   Convert to Kotlin and test in different Kotlin build target (node/jvm/binary).
-*   Update the osx binding to use non-legacy apis.
 
 That said, this library is perfectly usable today and tested on all systems. Checkout the badges above!
 
@@ -116,3 +115,4 @@ Source code of the library is available at its project page.
 
 *   [Java native access (JNA)](https://github.com/twall/jna)
 *   [Secret Service](https://github.com/swiesend/secret-service)
+*   [jkeychain](https://github.com/davidafsilva/jkeychain)

--- a/java-keyring/pom.xml
+++ b/java-keyring/pom.xml
@@ -38,6 +38,10 @@
             <artifactId>slf4j-api</artifactId>
         </dependency>
         <dependency>
+            <groupId>pt.davidafsilva.apple</groupId>
+            <artifactId>jkeychain</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.github.advisedtesting</groupId>
             <artifactId>AdvisedJunit4</artifactId>
             <scope>test</scope>

--- a/java-keyring/src/main/java/com/github/javakeyring/KeyringStorageType.java
+++ b/java-keyring/src/main/java/com/github/javakeyring/KeyringStorageType.java
@@ -30,11 +30,13 @@ import java.util.Arrays;
 
 import com.github.javakeyring.internal.KeyringBackend;
 import com.github.javakeyring.internal.freedesktop.FreedesktopKeyringBackend;
+import com.github.javakeyring.internal.osx.ModernOsxKeychainBackend;
 import com.github.javakeyring.internal.osx.OsxKeychainBackend;
 import com.github.javakeyring.internal.windows.WinCredentialStoreBackend;
 
 public enum KeyringStorageType {
-  OSX_KEYCHAIN(OsxKeychainBackend.class),
+  OSX_KEYCHAIN(ModernOsxKeychainBackend.class),
+  LEGACY_OSX_KEYCHAIN(OsxKeychainBackend.class),
   GNOME_KEYRING(FreedesktopKeyringBackend.class),
   WINDOWS_CREDENTIAL_STORE(WinCredentialStoreBackend.class);
   

--- a/java-keyring/src/main/java/com/github/javakeyring/internal/osx/ModernOsxKeychainBackend.java
+++ b/java-keyring/src/main/java/com/github/javakeyring/internal/osx/ModernOsxKeychainBackend.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright © 2019, Java Keyring
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the <organization> nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.github.javakeyring.internal.osx;
+
+import com.github.javakeyring.BackendNotSupportedException;
+import com.github.javakeyring.PasswordAccessException;
+import com.github.javakeyring.internal.KeyringBackend;
+
+import pt.davidafsilva.apple.OSXKeychain;
+import pt.davidafsilva.apple.OSXKeychainException;
+
+/**
+ * Keyring backend which uses modern OS X Keychain.
+ */
+public class ModernOsxKeychainBackend implements KeyringBackend {
+
+  private OSXKeychain keychain;
+
+  public ModernOsxKeychainBackend() throws BackendNotSupportedException {
+    if(System.getProperty("os.name", "").toLowerCase().contains("mac os")) {
+	  try {
+		keychain = OSXKeychain.getInstance();
+	  } catch (OSXKeychainException e) {
+		  throw new BackendNotSupportedException("Modern OSX Keychain not supported.", e);
+	  }
+    }
+    else {
+      throw new BackendNotSupportedException("Not running on Mac OS.");
+    }
+  }
+
+  /**
+   * Gets password from key store.
+   *
+   * @param service
+   *          Service name
+   * @param account
+   *          Account name
+   *
+   * @return Password related to specified service and account
+   *
+   * @throws PasswordAccessException
+   *           Thrown when an error happened while getting password
+   */
+  @Override
+  public String getPassword(String service, String account) throws PasswordAccessException {
+	try {
+		return keychain.findGenericPassword(service, account).orElseThrow(() -> new PasswordAccessException("No stored credentials match " + service + " account: " + account));
+	} catch (OSXKeychainException e) {
+		throw new PasswordAccessException("Failed to get credential. " + e.getMessage());
+	}
+  }
+
+  /**
+   * Sets password to key store.
+   *
+   * @param service
+   *          Service name
+   * @param account
+   *          Account name
+   * @param password
+   *          Password
+   *
+   * @throws PasswordAccessException
+   *           Thrown when an error happened while saving the password
+   */
+  @Override
+  public void setPassword(String service, String account, String password) throws PasswordAccessException {
+	try {
+      try {
+        getPassword(service, account);
+        keychain.modifyGenericPassword(service, account, password);
+      }
+	  catch(PasswordAccessException pae) {
+        keychain.addGenericPassword(service, account, password);
+      }
+    }
+    catch(OSXKeychainException e) {
+      throw new PasswordAccessException("Failed to set credential. " + e.getMessage());
+	}
+  }
+
+  /**
+   * Delete a password from the key store.
+   *
+   * @param service
+   *          Service name
+   * @param account
+   *          Account name
+   *
+   * @throws PasswordAccessException
+   *           Thrown when an error happened while saving the password
+   */
+  public void deletePassword(String service, String account) throws PasswordAccessException {
+	try {
+       keychain.deleteGenericPassword(service, account);
+    }
+    catch(OSXKeychainException e) {
+	  throw new PasswordAccessException("Failed to set credential. " + e.getMessage());
+    }
+  }
+
+  @Override
+  public void close() throws Exception {
+  }
+}

--- a/java-keyring/src/main/java/com/github/javakeyring/internal/osx/OsxKeychainBackend.java
+++ b/java-keyring/src/main/java/com/github/javakeyring/internal/osx/OsxKeychainBackend.java
@@ -34,14 +34,18 @@ import com.github.javakeyring.internal.KeyringBackend;
 import com.sun.jna.Pointer;
 
 /**
- * Keyring backend which uses OS X Keychain.
+ * Keyring backend which uses legacy OS X Keychain.
  */
 public class OsxKeychainBackend implements KeyringBackend {
 
   private final NativeLibraryManager nativeLibraries;
   
   public OsxKeychainBackend() throws BackendNotSupportedException {
-    nativeLibraries = new NativeLibraryManager();
+	if(System.getProperty("os.name", "").toLowerCase().contains("mac os")) {
+		nativeLibraries = new NativeLibraryManager();
+	}
+	else
+		throw new BackendNotSupportedException("Not running on Mac OS.");
   }
 
   /**

--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,11 @@
                 <version>1.7.30</version>
             </dependency>
             <dependency>
+                <groupId>pt.davidafsilva.apple</groupId>
+                <artifactId>jkeychain</artifactId>
+                <version>1.1.0</version>
+            </dependency>
+            <dependency>
                 <groupId>com.github.advisedtesting</groupId>
                 <artifactId>AdvisedJunit4</artifactId>
                 <version>1.3.1</version>


### PR DESCRIPTION
This delegates to a 3rd a party library, https://github.com/davidafsilva/jkeychain, much like the Linux support does. This particular backend will also check the `os.name` system property, as if we call into jkeychain blindly, it will automatically try to load it's own JNI library, which results in an ugly error about "stack guard" on Linux (before then throwing an exception).

The API for jkeychain is pretty much a 1-to-1 mapping for the java-keyring backend API.

The legacy API support has been left in for now. It should fallback to this if the modern method fails.