### PR TITLE
Fix markdown

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,16 +1,21 @@
 Copyright (c) 2012, east301
+Copyright (c) 2016-2023, Rex Hoffman and contributors
+
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:
-    * Redistributions of source code must retain the above copyright
-      notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-      notice, this list of conditions and the following disclaimer in the
-      documentation and/or other materials provided with the distribution.
-    * Neither the name of the east301 nor the
-      names of its contributors may be used to endorse or promote products
-      derived from this software without specific prior written permission.
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of east301 nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
 
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## Status ##
+## Status
 
 [![Build Status](https://github.com/javakeyring/java-keyring/actions/workflows/ci.yml/badge.svg)](https://github.com/javakeyring/java-keyring/actions/workflows/ci.yml)
 [![Maven Site](https://img.shields.io/badge/maven_site-1.0.1-green.svg)](https://javakeyring.github.io/java-keyring/1.0.1/)
@@ -6,58 +6,63 @@
 [![codebeat badge](https://codebeat.co/badges/ebdaafc6-987c-41bd-8902-e277334aac30)](https://codebeat.co/projects/github-com-javakeyring-java-keyring-master)
 [![codecov](https://codecov.io/gh/javakeyring/java-keyring/branch/master/graph/badge.svg)](https://codecov.io/gh/javakeyring/java-keyring)
 
-## Summary ##
+## Summary
 
 <img align="left" width="180" height="180" src="./src/site/resources/javakeyring.png">
 
-java-keyring is a small library which provides a simple java API to store passwords and secrets __insecurely__ in native os keystores.
+java-keyring is a small library which provides a simple java API to store passwords and secrets __insecurely__ in native OS keystores.
 
-Currently Mac OS X, Windows and Linux (GNOME or KDE) are supported.
+Currently, Mac OS X, Windows and Linux (GNOME or KDE) are supported.
 
-## History ##
+## History
 
 Initially an abandoned bitbucket repo, but lotsa love has been given to it.
-*   Proper windows credential store access.
-*   Delete support.
-*   Solid testing.
-*   Automated builds in all target environments, though KWallet needs seeded with an existing wallet.
+
+* Proper windows credential store access.
+* Delete support.
+* Solid testing.
+* Automated builds in all target environments, though KWallet needs seeded with an existing wallet.
 
 Initial repo: [https://bitbucket.org/east301/java-keyring](https://bitbucket.org/east301/java-keyring)
 
 Cloned from: [https://bitbucket.org/bpsnervepoint/java-keyring](https://bitbucket.org/bpsnervepoint/java-keyring)
 
-## Security Issues ##
+## Security Concerns
 
-CVE-2018-19358 (Vulnerability)
+[CVE-2018-19358](https://www.cve.org/CVERecord?id=CVE-2018-19358) (Vulnerability)
 
-There is a current investigation on the behaviour of the Secret Service API, as other applications can easily read any secret, if the keyring is unlocked (if a user is logged in, then the login/default collection is unlocked). Available D-Bus protection mechanisms (involving the busconfig and policy XML elements) are not used by default. The Secret Service API was never designed with a secure retrival mechanism.
+On GNOME, after the key ring is unlocked, all applications of the current user can access the passwords.
+According to [Debian's evaluation](https://security-tracker.debian.org/tracker/CVE-2018-19358), this is a non-issue.
+Workaround: Users can use separate key rings.
 
-* CVE-2018-19358 Base Score: __[7.8 HIGH]__, CVSS:3.0
-* GNOME Keyring Secret Service API Login Credentials Retrieval Vulnerability Base Score: __[5.5 Medium]__, CVSS:3.0
+Please keep in mind the above is not only about GNOME. Windows credentials [can be recovered easily](https://security.stackexchange.com/a/63909/37275).
 
-## Public Service Announcement ##
+Both Mac OS X and Windows will ask the runtime to allow the __Java runtime__ to connect to the key ring. This is an issue in case applications share the Java runtime: All of these applications can access the passwords stored in the key ring. This should be considered a vulnerability, as all java apps will be allowed access. I personally wouldn't store any credentials in the system keyring, ever, and especially on a system allowing any java application access.
 
-Please keep in mind the above isn't only about gnome/secret service.   Both os-x and window will ask the runtime to allow __java__ to connect to the key ring.  This should be considered a vunlrability, as all java apps will be allowed access.  I personally wouldn't store any credentials in the system keyring, ever, and especially on a system allowing any java app access.
+That said, I would be comfortable storing in plain text. For example, passwords you may be forced to store in `~/.m2/settings.xml` are development databases credentials, etc.). For any of the things a developer usually has to store in plain text because there is no better option would be fine to store in the key ring. At least you can look them up in all your tests/apps in a single location if you are consistent with your service/user naming. Hopefully, these developing services are not available to the internet, you VPN into them, right? They may have attack vectors as well. [strongSwan](https://www.strongswan.org/) is pretty easy to set up.
 
-That said, anything I would be comfortable storing in plain text would be fine.   For example, passwords you may be forced to store in ~/.m2/settings.xml, developement databases creds, etc) or any of the things a developer usually has to store in plain text because there is no better option would be fine to store in the keyring.  At least you can look them up in all your tests/apps in a single location if you are consistent with your service/user naming.  Hopefully these dev services are not available to the internet, you vpn in to them, right?  They may have attack vectors as well.  StrongSwan is pretty easy to set up.
+Use a real password manager for your real secrets. Something like [KeePassXC](https://keepassxc.org/), [Bitwarden](https://bitwarden.com/), Enpass, 1Password, etc. Keep that password manager locked - make sure it is setup to autolock after you login to something with it. Use a secondary factor if you can with important services, particularly financial, and e-mail, and if you're in to that sort of thing, social sites - like github.com.
 
-Use a real password manager for your real secrets. Something like Keypass, Enpass, 1Password, Bitwarden, etc.  Keep that password manager locked - make sure it's setup to autolock after you login to something with it.  Use a secondary factor if you can with important services, particularly financial, and e-mail, and if you're in to that sort of thing, social sites - like github.com.
+## Implementation
 
-## Implementation ##
+### Mac OS X
 
-__Mac OS X__
-*   Passwords are stored using [OS X Keychain](https://support.apple.com/guide/keychain-access/welcome/mac) using [Keychain Services](https://developer.apple.com/documentation/security/keychain_services/keychain_items). This is done either via built-in JNA bindings for the legacy API, or [jkeychain](https://github.com/davidafsilva/jkeychain). 
+* Passwords are stored using [OS X Keychain](https://support.apple.com/guide/keychain-access/welcome/mac) using [Keychain Services](https://developer.apple.com/documentation/security/keychain_services/keychain_items). This is done either via built-in [JNA](https://github.com/twall/jna) bindings for the legacy API, or [jkeychain](https://github.com/davidafsilva/jkeychain).
   
-__Linux/Freedesktop__
-*   Passwords are stored using either [DBus Secret Service](https://specifications.freedesktop.org/secret-service/) (you've probably used [Seahorse](https://en.wikipedia.org/wiki/Seahorse_(software))) via the excellent [secret-service](https://github.com/swiesend/secret-service) library, or KWallet under KDE.
+### Linux/Freedesktop
 
-__Windows__
-*   Passwords are stored using [Credential Manager](https://support.microsoft.com/en-us/help/4026814/windows-accessing-credential-manager), exceptions will contain [Error Codes](https://docs.microsoft.com/en-us/windows/win32/debug/system-error-codes).   Access is via the [Wincred](https://docs.microsoft.com/en-us/windows/win32/api/wincred/) api.  
-Windows seems prone to race conditions where reads/writes may not be immediately visible.
+* Passwords are stored using either [DBus Secret Service](https://specifications.freedesktop.org/secret-service/) (you've probably used [Seahorse](https://en.wikipedia.org/wiki/Seahorse_(software))) via the excellent [secret-service](https://github.com/swiesend/secret-service) library, or [KWallet](https://apps.kde.org/de/kwalletmanager5/) under KDE.
 
-## Usage ##
+### Windows
 
-Dirt simple:
+* Passwords are stored using [Credential Manager](https://support.microsoft.com/en-us/help/4026814/windows-accessing-credential-manager), exceptions will contain [Error Codes](https://docs.microsoft.com/en-us/windows/win32/debug/system-error-codes). Access is via the [Wincred](https://docs.microsoft.com/en-us/windows/win32/api/wincred/) API.
+* Windows seems prone to race conditions where reads/writes may not be immediately visible.
+
+## Usage
+
+The library is available at Maven central: <https://central.sonatype.com/artifact/com.github.javakeyring/java-keyring>.
+
+The most simple usage is as follows:
 
 ```java
     try (Keyring keyring = Keyring.create()) {
@@ -67,7 +72,7 @@ Dirt simple:
     }
 ```
 
-Recommend creating a dummy value if getPassword() fails, so that users know where to go set the value in their applications.
+Recommend creating a dummy value if `getPassword()` fails, so that users know where to go set the value in their applications.
 
 ```java
     try (final Keyring keyring = Keyring.create()) {
@@ -85,36 +90,33 @@ Recommend creating a dummy value if getPassword() fails, so that users know wher
     }
 ```
 
-## Building ##
+## Building
 
 ```bash
 mvn clean install -Dgpg.skip=true
 ```
 
-## License ##
+## License
 
-Source code of java-keyring is available under a BSD license. 
-See the file LICENSE.EAST301 for more details.
+Source code of java-keyring is available under a BSD license.
+See the file [`LICENSE`](LICENSE) for more details.
 
-## PRs are Welcome ##
+## PRs are Welcome
 
 Outstanding work:
 
-*   Windows error message conversion.
-*   Windows has no locking/session mechanism allowing for races between threads (like the maven tests in this project).
-*   Provide easy binding for Spring / CDI / etc.
-*   Support for build tools like Maven/Gradle.
-*   Perhaps optional UI requests for passwords (Wincred/secret-service have Apis at least to prompt users).
-*   Convert to Kotlin and test in different Kotlin build target (node/jvm/binary).
+* Windows error message conversion.
+* Windows has no locking/session mechanism allowing for races between threads (like the maven tests in this project).
+* Provide easy binding for Spring / CDI / etc.
+* Perhaps optional UI requests for passwords (Wincred/secret-service have APIs at least to prompt users).
+* Convert to Kotlin and test in different Kotlin build target (node/jvm/binary).
 
 That said, this library is perfectly usable today and tested on all systems. Checkout the badges above!
 
-## Special Thanks ##
+## Special Thanks
 
-java-keyring uses the following library, thanks a lot!
-java-keyring package contains copy of compiled JNA library. 
-Source code of the library is available at its project page.
+java-keyring uses the following libraries, thanks a lot!
 
-*   [Java native access (JNA)](https://github.com/twall/jna)
-*   [Secret Service](https://github.com/swiesend/secret-service)
-*   [jkeychain](https://github.com/davidafsilva/jkeychain)
+* [Java native access (JNA)](https://github.com/twall/jna)
+* [Secret Service](https://github.com/swiesend/secret-service)
+* [jkeychain](https://github.com/davidafsilva/jkeychain)


### PR DESCRIPTION
This PR refines README.md and the license file

README.md

- Make CVE text more precise and less frightening.
- Add Maven central coordinates
- Remove TODO in list: "Support for build tools like Maven/Gradle"
- Apply rules of [markdown-lint](https://marketplace.visualstudio.com/items?itemName=DavidAnson.vscode-markdownlint)