### PR TITLE
Bump secret-service version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
             <dependency>
                 <groupId>de.swiesend</groupId>
                 <artifactId>secret-service</artifactId>
-                <version>1.0.0</version>
+                <version>1.8.1-jdk17</version>
                 <exclusions>
                     <exclusion>
                         <groupId>org.slf4j</groupId>


### PR DESCRIPTION
There seem to be some problems with the old version of secret-service and dbus we ran into (see https://github.com/swiesend/secret-service/issues/31). Hopefully using the latest version of secret-service fixes them.