### PR TITLE
Switch from native-unixsocket to jnr-unixsocket

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,9 @@ jobs:
             distribution: 'adopt'
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+        with:
+          show-progress: 'false'
       - name: Install packages on linux
         run: >
           if [ "$(expr substr $(uname -s) 1 5)" == "Linux" ] && [ "${{matrix.keyring}}" == "gnome" ]; then
@@ -46,6 +48,7 @@ jobs:
         with:
           distribution: ${{ matrix.distribution }}
           java-version: ${{ matrix.java-version }}
+          cache: 'maven'
       - name: Maven Install (macos, windows)
         if: (matrix.os != 'ubuntu-latest')
         run: mvn --batch-mode --update-snapshots -Dgpg.skip=true install

--- a/java-keyring/pom.xml
+++ b/java-keyring/pom.xml
@@ -24,6 +24,26 @@
         <dependency>
             <groupId>de.swiesend</groupId>
             <artifactId>secret-service</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.github.hypfvieh</groupId>
+                    <artifactId>dbus-java-transport-native-unixsocket</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.github.hypfvieh</groupId>
+                    <artifactId>dbus-java-core</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>com.github.hypfvieh</groupId>
+            <artifactId>dbus-java-transport-jnr-unixsocket</artifactId>
+            <version>4.3.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.github.hypfvieh</groupId>
+            <artifactId>dbus-java-core</artifactId>
+            <version>4.3.0</version>
         </dependency>
         <dependency>
             <groupId>net.java.dev.jna</groupId>

--- a/java-keyring/src/main/java/com/github/javakeyring/internal/KeyringBackendFactory.java
+++ b/java-keyring/src/main/java/com/github/javakeyring/internal/KeyringBackendFactory.java
@@ -88,10 +88,10 @@ public class KeyringBackendFactory {
       throws BackendNotSupportedException {
     KeyringBackend backend;
     try {
-      backend = (KeyringBackend) keyring
+      backend = keyring
               .getSupportingClass()
               .getConstructor(new Class[] {})
-              .newInstance(new Object[]{});
+              .newInstance();
     } catch (InvocationTargetException | IllegalAccessException | NoSuchMethodException | InstantiationException ex) {
       if (throwing) {
         throw new BackendNotSupportedException("Could not instantiate backend", ex);

--- a/java-keyring/src/test/java/com/github/javakeyring/freedesktop/FreedesktopKeyringBackedTest.java
+++ b/java-keyring/src/test/java/com/github/javakeyring/freedesktop/FreedesktopKeyringBackedTest.java
@@ -67,7 +67,7 @@ public class FreedesktopKeyringBackedTest {
    */
   @Test
   public void testPasswordFlow() throws Exception {
-    //assumeTrue(Platform.isLinux() && Keyring.create().getKeyringStorageType() == KeyringStorageType.GNOME_KEYRING);
+    assumeTrue(Platform.isLinux() && Keyring.create().getKeyringStorageType() == KeyringStorageType.GNOME_KEYRING);
     FreedesktopKeyringBackend backend = new FreedesktopKeyringBackend();
     catchThrowable(() -> backend.deletePassword(SERVICE, ACCOUNT));
     checkExistenceOfPasswordEntry(backend);


### PR DESCRIPTION
The secret-service library cannot deal with `abstract` sockets. These, however, are created by DBUS (as outlined at https://unix.stackexchange.com/q/184964/18033).

This PR replaces ´dbus-java-transport-native-unixsocket` back to `dbus-java-transport-jnr-unixsocket`. 

Reason: `native-unixsocket` does not support `abstract`:  The [JEP-380](https://openjdk.org/jeps/380) tells so: ![image](https://github.com/swiesend/secret-service/assets/1366654/8f24acb4-db1a-467e-ad2e-1e38d9c38c45)

Failing tests:

com.github.javakeyring.freedesktop.FreedesktopKeyringBackedTest.testPasswordFlow:  java.security.AccessControlException: The collection was not unlocked with user permission

and two more. I think, because of the unlocking issue.
